### PR TITLE
Query builder fixes for latest version

### DIFF
--- a/src/Cygnite/Common/Pagination.php
+++ b/src/Cygnite/Common/Pagination.php
@@ -19,20 +19,19 @@ use Cygnite\Common\UrlManager\Url;
 if (!defined('CF_SYSTEM')) {
     exit('External script access not allowed');
 }
-/*
- * Pagination.
- *
- * @author Sanjoy Dey <dey.sanjoy0@gmail.com>
+
+/**
+ * Class Pagination
  *
  * <code>
  * $paginator = new \Cygnite\Common\Pagination;
- * $paginator->getItems();
- * $paginator->getTotalNumOfItems();
+ * $paginator->setTotalNumberOfPage();
  * $paginator->setPerPage(5);
  * $paginator->createLinks();
  * </code>
+ *
+ * @package Cygnite\Common
  */
-
 class Pagination
 {
     protected $perPage = '15';
@@ -62,12 +61,14 @@ class Pagination
     protected $totalNumOfPage;
 
     /**
+     * Pagination constructor
+     *
      * @param $model
      */
     public function __construct($model = null)
     {
         if (!is_null($model) && is_object($model)) {
-        $this->model = $model;
+            $this->model = $model;
         }
 
         $this->setCurrentPageUrl();
@@ -88,7 +89,7 @@ class Pagination
     }
 
     /**
-     * Set per page
+     * Set per page record
      *
      * @param null $number
      * @return $this
@@ -98,28 +99,25 @@ class Pagination
         if (is_null($number)) {
             if (property_exists($this->model, 'perPage')) {
                 $this->perPage = $this->model->perPage;
-
                 return $this;
             }
         }
 
-            $this->perPage = $number;
+        $this->perPage = $number;
 
         return $this;
     }
 
     /**
+     * Set total number of pages
+     *
      * @param null $number
      * @return $this
      */
     public function setTotalNumberOfPage($number = null)
     {
         if (is_null($number)) {
-            $modelClass = Inflector::getClassNameFromNamespace(get_class($this->model));
-            $table = Inflector::tabilize($modelClass);
-
-            $numRecords = $this->model->select($this->count()." AS ".$this->numCount)->findMany();
-
+            $numRecords = $this->model->select($this->count()." AS ".$this->numCount)->findOne();
             $this->totalNumOfPage = $numRecords[0]->{$this->numCount};
 
             return $this;
@@ -139,6 +137,8 @@ class Pagination
     }
 
     /**
+     * Make the count row
+     *
      * @param string $count
      * @return string
      */
@@ -150,6 +150,8 @@ class Pagination
     }
 
     /**
+     * Render the pagination links
+     *
      * @return string
      */
     public function __toString()
@@ -157,6 +159,10 @@ class Pagination
         return (string) $this->render();
     }
 
+    /**
+     * Calculate the pagination links
+     *
+     */
     public function calculate()
     {
         $this->calculatePageLimitAndOffset();
@@ -177,6 +183,9 @@ class Pagination
         $this->create();
     }
 
+    /**
+     * Calculate page limit and offset
+     */
     private function calculatePageLimitAndOffset()
     {
         $pageUri = '';
@@ -194,6 +203,9 @@ class Pagination
         $this->setPaginationOffset($start);
     }
 
+    /**
+     * Set current page url
+     */
     private function setCurrentPageUrl()
     {
         $controller = Url::segment(1);
@@ -203,26 +215,51 @@ class Pagination
         $this->currentPageUrl = Url::getBase().$controller.'/'.$method;
     }
 
+    /**
+     * Set page number
+     *
+     * @param $number
+     */
     public function setPageNumber($number)
     {
         $this->pageNumber = intval($number);
     }
 
+    /**
+     * Get page number
+     *
+     * @return null
+     */
     public function getPageNumber()
     {
         return (isset($this->pageNumber)) ? $this->pageNumber : null;
     }
 
+    /**
+     * Set pagination offset
+     *
+     * @param $offset
+     */
     public function setPaginationOffset($offset)
     {
         $this->paginationOffset = intval($offset);
     }
 
+    /**
+     * Get Pagination offset
+     *
+     * @return null
+     */
     public function getPaginationOffset()
     {
         return (isset($this->paginationOffset)) ? $this->paginationOffset : null;
     }
 
+    /**
+     * Create pagination links
+     *
+     * @return $this
+     */
     public function createLinks()
     {
         $this->getTotalNumberOfPages();
@@ -380,7 +417,12 @@ class Pagination
         return $content;
     }
 
-    private function render()
+    /**
+     * Render pagination links
+     *
+     * @return mixed
+     */
+    protected function render()
     {
         return $this->paginationLinks;
     }

--- a/src/Cygnite/Database/Cyrus/ActiveRecordInterface.php
+++ b/src/Cygnite/Database/Cyrus/ActiveRecordInterface.php
@@ -144,7 +144,7 @@ interface ActiveRecordInterface extends \ArrayAccess
      * We will get Fluent Query Object
      * @return Query
      */
-    public function query();
+    public function queryBuilder();
 
     /**
      * Use Connection to build fluent queries against any table

--- a/src/Cygnite/Database/Query/Builder.php
+++ b/src/Cygnite/Database/Query/Builder.php
@@ -1074,13 +1074,13 @@ class Builder extends Joins implements QueryBuilderInterface
     /**
      * Find result using raw sql query
      *
-     * @param $arguments
+     * @param $sql
      * @return Collection
      */
-    public function findBySql($arguments)
+    public function findBySql($sql)
     {
         $results = [];
-        $stmt = $this->resolveConnection()->prepare(trim($arguments[0]));
+        $stmt = $this->resolveConnection()->prepare(trim($sql));
         $stmt->execute();
         $results = $this->fetchAs($stmt);
 

--- a/src/Cygnite/Database/Query/Builder.php
+++ b/src/Cygnite/Database/Query/Builder.php
@@ -955,7 +955,7 @@ class Builder extends Joins implements QueryBuilderInterface
      * @throws \Exception|\PDOException
      * @return object                   pointer $this
      */
-    public function query($sql, $attributes = [])
+    public function sql($sql, $attributes = [])
     {
         try {
             $this->statement = $this->resolveConnection()->prepare($sql);

--- a/src/Cygnite/Database/Query/QueryBuilderInterface.php
+++ b/src/Cygnite/Database/Query/QueryBuilderInterface.php
@@ -195,7 +195,7 @@ interface QueryBuilderInterface
      * @throws \Exception|\PDOException
      * @return object                   pointer $this
      */
-    public function query($sql, $attributes = []);
+    public function sql($sql, $attributes = []);
 
     /**
      * @return mixed


### PR DESCRIPTION
Renamed the method query() to queryBuilder(), so that user will can access to PDO query() method.
Fixed findBySql() / sql() method for running raw queries, and code clean up in Pagination class.