### PR TITLE
Removed datetime column from migrations table schema- It thorws exception in mysql 5.7.9

### DIFF
--- a/src/Cygnite/Database/Table/Table.php
+++ b/src/Cygnite/Database/Table/Table.php
@@ -156,7 +156,7 @@ class Table
                         'increment' => true, 'key' => 'primary', ],
                     ['column' => 'migration', 'type' => 'string', 'length' => 255],
                     ['column' => 'version', 'type' => 'int', 'null' => true],
-                    ['column' => 'created_at',  'type' => 'datetime'],
+                    //['column' => 'created_at',  'type' => 'datetime'],
                 ], 'InnoDB', 'latin1'
             );
         });


### PR DESCRIPTION
Issue: #94 