### PR TITLE
Added codesniffer, .gitattributes file and fixed linting in composer.json

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+* text=auto
+
+/tests export-ignore
+.gitignore export-ignore
+.gitattributes export-ignore
+.travis.yml export-ignore
+phpcs.xml export-ignore
+phpunit.xml export-ignore
+phpunit.php export-ignore

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "cygnite/framework",
     "description": "Cygnite PHP Framework",
+    "type": "library",
     "keywords": ["Cygnite", "PHP", "Framework"],
     "homepage": "http://www.cygniteframework.com",
     "license": "MIT",
@@ -8,17 +9,13 @@
         "issues": "https://github.com/cygnite/framework/issues",
         "source": "https://github.com/cygnite/framework"
     },
-    "authors": [
-        {
-            "name": "Sanjoy Dey",
-            "email": "dey.sanjoy0@gmail.com"
-        },
-        {
-            "name": "Cygnite Contributors",
-            "homepage": "https://github.com/cygnite/framework/graphs/contributors"
-        }
-
-    ],
+    "authors": [{
+        "name": "Sanjoy Dey",
+        "email": "dey.sanjoy0@gmail.com"
+    }, {
+        "name": "Cygnite Contributors",
+        "homepage": "https://github.com/cygnite/framework/graphs/contributors"
+    }],
     "require": {
         "php": ">=7.0",
         "twig/twig": "2.1.*",
@@ -27,26 +24,25 @@
         "ircmaxell/password-compat": "1.0.*",
         "swiftmailer/swiftmailer": "5.4.*",
         "monolog/monolog": "~1.22",
-	"nesbot/carbon": "~1.20",
-	"league/flysystem": "~1.0",
-	"symfony/finder": "~3.2"
-   },
-   "require-dev": {
-       "mockery/mockery": "~0.9.7",
-       "phpunit/phpunit": "~6.0",
-       "predis/predis": "1.1.*"
+        "nesbot/carbon": "~1.20",
+        "league/flysystem": "~1.0",
+        "symfony/finder": "~3.2"
+    },
+    "require-dev": {
+        "mockery/mockery": "~0.9.7",
+        "phpunit/phpunit": "~6.0",
+        "predis/predis": "1.1.*",
+        "squizlabs/php_codesniffer": "^2.8"
     },
     "autoload": {
-     	"files": [
-            "src/Cygnite/Helpers/Support.php"
-        ],
+        "files": ["src/Cygnite/Helpers/Support.php"],
         "psr-4": {
-            "Cygnite\\": "src/Cygnite/"
+            "Cygnite\\": "src/Cygnite"
         }
     },
-	"autoload-dev": {
+    "autoload-dev": {
         "psr-4": {
-            "Cygnite\\Tests\\": "tests/Cygnite/"
+            "Cygnite\\Tests\\": "tests/Cygnite"
         }
     },
     "extra": {
@@ -54,5 +50,9 @@
             "dev-master": "3.0-dev"
         }
     },
-    "minimum-stability": "dev"
+    "config": {
+        "sort-packages": true
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<ruleset name="Cygnite Coding Standard">
+    <description>Coding standard for cygnite.</description>
+    <arg value="np"/>
+    <arg name="colors"/>
+    <rule ref="PSR2"/>
+    <file>./src/Cygnite</file>
+</ruleset>


### PR DESCRIPTION
**Composer.json**
Fixed formatting
Added Library type option
Added Sort packages option
Added in require-dev: phpcodesniffer

**.gitattributes**
Making sure that public won't download unnecessary files while requiring it in vendor folder as library package.

**phpcs.xml**
Xml file for php_codesniffer settings

Commands:
./vendor/bin/phpcs
to check for PSR2 coding standards in src/Cygnite the core directory.

./vendor/binphpcbf
fixes the files for PSR2 coding standard.
